### PR TITLE
fixed sql request

### DIFF
--- a/src/Uvweb/UvBundle/Controller/WebServiceController.php
+++ b/src/Uvweb/UvBundle/Controller/WebServiceController.php
@@ -85,7 +85,7 @@ class WebServiceController extends BaseController
             ->createQueryBuilder('u')
             ->select('u.id, u.name, u.title, u.tp, u.final')
             ->where('u.name = :uvname')
-            ->andWhere('u.uni = NULL')
+            ->andWhere('u.uni IS NULL')
             ->setParameter('uvname', $uvname)
             ->getQuery()
             ->getArrayResult();


### PR DESCRIPTION
This PR fixes a web service endpoint, that used to crash when called, thus rendering a 500 error. The issue came from a SQL statement (and a problem with a `= NULL` value, instead of `IS NULL`).